### PR TITLE
Fix GPU crashes and improve resource management

### DIFF
--- a/src/Application/gpu_utils.cpp
+++ b/src/Application/gpu_utils.cpp
@@ -273,6 +273,13 @@ bool upload_texture_data_to_gpu(unsigned char *image_data, int width,
 #endif
   if (image_data == nullptr || width <= 0 || height <= 0 || device == nullptr ||
       out_texture == nullptr) {
+    if (image_data != nullptr) {
+      if (free_with_stbi) {
+        stbi_image_free(image_data);
+      } else {
+        IM_FREE(image_data);
+      }
+    }
     return false;
   }
 

--- a/src/Application/gpu_utils.cpp
+++ b/src/Application/gpu_utils.cpp
@@ -271,15 +271,20 @@ bool upload_texture_data_to_gpu(unsigned char *image_data, int width,
 #ifdef TRACY_ENABLE
   ZoneScopedN("upload_texture_data_to_gpu");
 #endif
-  if (image_data == nullptr || width <= 0 || height <= 0 || device == nullptr ||
-      out_texture == nullptr) {
+  auto cleanup = [&]() {
     if (image_data != nullptr) {
       if (free_with_stbi) {
         stbi_image_free(image_data);
       } else {
         IM_FREE(image_data);
       }
+      image_data = nullptr;
     }
+  };
+
+  if (image_data == nullptr || width <= 0 || height <= 0 || device == nullptr ||
+      out_texture == nullptr) {
+    cleanup();
     return false;
   }
 
@@ -297,11 +302,7 @@ bool upload_texture_data_to_gpu(unsigned char *image_data, int width,
   if (texture == nullptr) {
     std::cerr << "Failed to create GPU texture: " << SDL_GetError()
               << std::endl;
-    if (free_with_stbi) {
-      stbi_image_free(image_data);
-    } else {
-      IM_FREE(image_data);
-    }
+    cleanup();
     return false;
   }
 
@@ -314,11 +315,7 @@ bool upload_texture_data_to_gpu(unsigned char *image_data, int width,
     std::cerr << "Failed to create GPU transfer buffer: " << SDL_GetError()
               << std::endl;
     SDL_ReleaseGPUTexture(device, texture);
-    if (free_with_stbi) {
-      stbi_image_free(image_data);
-    } else {
-      IM_FREE(image_data);
-    }
+    cleanup();
     return false;
   }
 
@@ -349,11 +346,7 @@ bool upload_texture_data_to_gpu(unsigned char *image_data, int width,
   SDL_SubmitGPUCommandBuffer(cmd);
   SDL_ReleaseGPUTransferBuffer(device, transfer_buffer);
 
-  if (free_with_stbi) {
-    stbi_image_free(image_data);
-  } else {
-    IM_FREE(image_data);
-  }
+  cleanup();
 
   *out_texture = texture;
   return true;

--- a/src/Application/image.cpp
+++ b/src/Application/image.cpp
@@ -542,6 +542,9 @@ void ImageEditor::load_path(std::filesystem::path path) {
 
   unsigned char *dst = resize_image_rgba8(src, src_w, src_h, dst_w, dst_h);
   stbi_image_free(src);
+  if (image_src != nullptr) {
+    IM_FREE(image_src);
+  }
   image_src = dst;
   width = dst_w;
   height = dst_h;

--- a/src/Application/image_editor.cpp
+++ b/src/Application/image_editor.cpp
@@ -7,11 +7,36 @@
 #include <gegl.h>
 
 ImageEditor::~ImageEditor() {
-  if (preview_texture != nullptr)
+  if (preview_texture != nullptr) {
     SDL_ReleaseGPUTexture(device, preview_texture);
+    preview_texture = nullptr;
+  }
+  cleanup_stale_resources();
+
+  if (graph != nullptr) {
+    g_object_unref(graph);
+    graph = nullptr;
+  }
+  if (image_buffer != nullptr) {
+    g_object_unref(image_buffer);
+    image_buffer = nullptr;
+  }
+  if (image_src != nullptr) {
+    IM_FREE(image_src);
+    image_src = nullptr;
+  }
+}
+
+void ImageEditor::cleanup_stale_resources() {
+  for (auto *tex : textures_to_release) {
+    SDL_ReleaseGPUTexture(device, tex);
+  }
+  textures_to_release.clear();
 }
 
 void ImageEditor::prepare_gegl_graph() {
+  effects.clear();
+
   // Clean up previous graph and buffer
   if (graph != nullptr) {
     g_object_unref(graph);
@@ -49,6 +74,8 @@ void ImageEditor::apply_gegl_texture() {
   GeglRectangle roi = {0, 0, width, height};
   const size_t buf_size = static_cast<size_t>(width) * height * 4;
   unsigned char *pixels = static_cast<unsigned char *>(IM_ALLOC(buf_size));
+  if (pixels == nullptr)
+    return;
 
   gegl_node_blit(sink,
                  1.0, // scale — 1:1 since you already downsampled via stbir
@@ -56,11 +83,13 @@ void ImageEditor::apply_gegl_texture() {
                  GEGL_BLIT_DEFAULT);
 
   SDL_GPUTexture *texture = nullptr;
-  upload_texture_data_to_gpu(pixels, width, height, device, &texture, false);
-  if (preview_texture != nullptr) {
-    SDL_ReleaseGPUTexture(device, preview_texture);
+  if (upload_texture_data_to_gpu(pixels, width, height, device, &texture,
+                                  false)) {
+    if (preview_texture != nullptr) {
+      textures_to_release.push_back(preview_texture);
+    }
+    preview_texture = texture;
   }
-  preview_texture = texture;
 }
 
 Effect &ImageEditor::get_or_create_effect(EffectType type) {

--- a/src/Application/image_editor.h
+++ b/src/Application/image_editor.h
@@ -38,8 +38,10 @@ public:
     pan = next_pan;
   }
   void render_controls();
+  void cleanup_stale_resources();
 
 private:
+  std::vector<SDL_GPUTexture *> textures_to_release;
   SDL_GPUDevice *device = nullptr;
   float zoom = 0.0f;
   ImVec2 canvas_size = ImVec2(0.0f, 0.0f);

--- a/src/Application/ui.cpp
+++ b/src/Application/ui.cpp
@@ -110,10 +110,12 @@ void ImageEditor::render_preview() {
       canvas_pos,
       ImVec2(canvas_pos.x + canvas_size.x, canvas_pos.y + canvas_size.y), true);
   const ImVec2 image_pos = {canvas_pos.x + pan.x, canvas_pos.y + pan.y};
-  draw_list->AddImage(
-      texture_id, image_pos,
-      ImVec2(image_pos.x + image_size.x, image_pos.y + image_size.y),
-      ImVec2(0, 0), ImVec2(1, 1));
+  if (texture_id != nullptr) {
+    draw_list->AddImage(
+        texture_id, image_pos,
+        ImVec2(image_pos.x + image_size.x, image_pos.y + image_size.y),
+        ImVec2(0, 0), ImVec2(1, 1));
+  }
 
   draw_list->PopClipRect();
   ImGui::EndChild();
@@ -295,6 +297,7 @@ void ImageManager::render_manager() {
 #ifdef TRACY_ENABLE
   ZoneScopedN("ImageManager::draw_manager");
 #endif
+  editor.cleanup_stale_resources();
   apply_pending_selection();
   if (with_preview && current_image_ != nullptr && current_image_->is_valid() &&
       (editor.preview_texture == nullptr ||

--- a/src/Application/ui.cpp
+++ b/src/Application/ui.cpp
@@ -110,7 +110,7 @@ void ImageEditor::render_preview() {
       canvas_pos,
       ImVec2(canvas_pos.x + canvas_size.x, canvas_pos.y + canvas_size.y), true);
   const ImVec2 image_pos = {canvas_pos.x + pan.x, canvas_pos.y + pan.y};
-  if (texture_id != nullptr) {
+  if (preview_texture != nullptr) {
     draw_list->AddImage(
         texture_id, image_pos,
         ImVec2(image_pos.x + image_size.x, image_pos.y + image_size.y),

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -257,16 +257,6 @@ void render_sessions(std::deque<std::unique_ptr<Session>> &sessions) {
 
 int main(int, char **) {
   prepare_database();
-
-  if (char *base_path = SDL_GetBasePath()) {
-    std::filesystem::path babl_path =
-        std::filesystem::path(base_path).parent_path() / "lib" / "babl-0.1";
-    if (std::filesystem::exists(babl_path)) {
-      SDL_setenv("BABL_PATH", babl_path.string().c_str(), 1);
-    }
-    SDL_free(base_path);
-  }
-
   gegl_init(0, nullptr);
   srand(time(NULL));
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -257,6 +257,16 @@ void render_sessions(std::deque<std::unique_ptr<Session>> &sessions) {
 
 int main(int, char **) {
   prepare_database();
+
+  if (char *base_path = SDL_GetBasePath()) {
+    std::filesystem::path babl_path =
+        std::filesystem::path(base_path).parent_path() / "lib" / "babl-0.1";
+    if (std::filesystem::exists(babl_path)) {
+      SDL_setenv("BABL_PATH", babl_path.string().c_str(), 1);
+    }
+    SDL_free(base_path);
+  }
+
   gegl_init(0, nullptr);
   srand(time(NULL));
 


### PR DESCRIPTION
This PR addresses two random crashes occurring during slider manipulation and a warning related to BABL_PATH.

Crash 1 (null texture binding) and Crash 2 (use-after-free/double-free) were caused by immediate release of GPU textures while they were still being referenced by the current frame's ImGui draw lists. A deferred release mechanism was implemented in `ImageEditor` to ensure textures are only destroyed at the beginning of the next frame.

Memory management was audited and improved:
- `upload_texture_data_to_gpu` now reliably frees its input buffer on all return paths.
- `ImageEditor` now correctly cleans up `GeglGraph`, `GeglBuffer`, and the source image buffer.
- The `effects` vector is cleared when the graph is rebuilt to prevent using stale pointers.
- Defensive null checks were added to `render_preview`.

The `BABL_PATH` warning is resolved by automatically searching for the `babl-0.1` plugins directory relative to the executable path and setting the environment variable accordingly.

---
*PR created automatically by Jules for task [7535183235040383044](https://jules.google.com/task/7535183235040383044) started by @clodman84*