### PR TITLE
Migrate to Meson Build System and Add Documentation

### DIFF
--- a/HOWTOBUILD.md
+++ b/HOWTOBUILD.md
@@ -1,0 +1,72 @@
+# HOWTOBUILD - UNFV3
+
+This guide provides instructions for building UNFV3 from source using the Meson build system.
+
+## Prerequisites
+
+- **C++20 Compiler**: GCC 11+, Clang 13+, or MSVC 2022+.
+- **Meson** (1.0+) and **Ninja**.
+- **GEGL 0.4**: Development headers must be installed on your system.
+  - Linux: `sudo apt install libgegl-dev`
+  - macOS: `brew install gegl`
+  - Windows: Ensure GEGL is in your `PKG_CONFIG_PATH`.
+- **CMake**: Required by Meson to build the vendored SDL3 and OpenCV subprojects.
+
+## Development Build
+
+To set up a build directory for development (with debug symbols and no LTO):
+
+```bash
+# Initialize the build directory
+meson setup build -Dbuildtype=debug
+
+# Compile the project
+ninja -C build
+
+# Run the application
+./build/UNFV3
+```
+
+### Enabling Tracy Profiler
+
+To build with Tracy instrumentation:
+
+```bash
+meson setup build_tracy -Dtracy=true
+ninja -C build_tracy
+```
+
+## Distribution Build
+
+For a highly optimized release build:
+
+```bash
+# Initialize with release settings (O3 and LTO are enabled by default in our meson.build)
+meson setup build_release --buildtype=release
+
+# Compile
+ninja -C build_release
+```
+
+## Cross-Platform Notes
+
+### Windows (MSVC)
+
+1. Open the "Developer Command Prompt for VS 2022".
+2. Run the `meson setup` command. Meson will automatically detect the MSVC compiler.
+
+### Linux
+
+Ensure that `pkg-config` can find `gegl-0.4.pc`. If you installed GEGL in a non-standard location, set your `PKG_CONFIG_PATH` accordingly.
+
+### macOS
+
+The build system supports Apple Silicon. Ensure you have the latest Xcode Command Line Tools installed.
+
+## Troubleshooting
+
+- **Missing Subprojects**: The build system expects SDL3 and OpenCV in `vendored/`. If they are missing, ensure you have initialized git submodules:
+  ```bash
+  git submodule update --init --recursive
+  ```
+- **GEGL Not Found**: If `dependency('gegl-0.4')` fails, verify that `pkg-config --modversion gegl-0.4` works in your terminal.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,47 @@
+# API Documentation
+
+This document describes the primary classes and methods in the UNFV3 codebase.
+
+## `ImageEditor`
+
+The central class for image manipulation.
+
+### Methods
+- `load_path(std::filesystem::path)`: Loads an image from disk into the GEGL processing graph.
+- `render_controls()`: Renders the ImGui UI for all active image effects.
+- `render_preview()`: Orchestrates the rendering of the processed image to the screen.
+- `get_or_create_effect(EffectType type)`: Manages the lifecycle of GEGL nodes in the processing chain.
+
+## `Session`
+
+Manages a workspace consisting of an image folder and a set of search/billing data.
+
+### Methods
+- `render_searcher()`: Displays the UI for searching the database and adding images to the current session.
+- `render_billed()`: Shows the list of images tagged or "billed" in the current session.
+- `export_images()`: Processes and saves the final edited images to a specified directory.
+
+## `ImageManager`
+
+Handles the collection of images within a session folder.
+
+### Methods
+- `load_thumbnails()`: Loads small versions of all images in the folder for the carousel view.
+- `render_manager()`: Displays the image viewer and the carousel UI.
+- `load_next()` / `load_previous()`: Navigates through the image collection.
+
+## `Database`
+
+Wraps SQLite for metadata storage and retrieval.
+
+### Methods
+- `search(TokenType, std::string, ...)`: Performs a search based on full-text search (FTS), IDs, or other criteria.
+- `read_csv(std::string)`: Imports metadata from a CSV file into the SQLite database.
+
+## `GPU Utils`
+
+Found in `gpu_utils.h/cpp`, these helper functions facilitate interaction with the SDL3 GPU API.
+
+### Functions
+- `upload_texture_data_to_gpu(...)`: Creates a GPU texture and uploads pixel data.
+- `create_gpu_buffer(...)`: Allocates a buffer on the GPU.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,35 @@
+# Architecture Overview
+
+UNFV3 is a cross-platform image editing and management application. Its architecture is built around three core pillars:
+
+1.  **SDL3 GPU Abstraction**: Used for all rendering and texture management. It provides a modern, low-level API for high-performance graphics while maintaining cross-platform compatibility.
+2.  **GEGL (Generic Graphics Library)**: The powerhouse behind image processing. UNFV3 utilizes GEGL's graph-based architecture to chain non-destructive image effects.
+3.  **Dear ImGui**: Provides the immediate-mode user interface, integrated with SDL3's GPU backend for seamless rendering.
+
+## High-Level Component Diagram
+
+```text
++---------------------------------------+
+|              Main Loop                |
+|  (SDL Events, ImGui Frame, Render)    |
++---------+--------------------+--------+
+          |                    |
+          v                    v
++------------------+  +----------------------+
+|     Session      |  |     ImageEditor      |
+| (Management, DB) |  | (GEGL Graph, GPU Tx) |
++---------+--------+  +----------+-----------+
+          |                      |
+          v                      v
++------------------+  +----------------------+
+|     Database     |  |    GEGL Operations   |
+| (SQLite Search)  |  | (Filters & Effects)  |
++------------------+  +----------------------+
+```
+
+## Data Flow
+
+1.  **Image Loading**: Images are loaded into `GeglBuffer` for processing and as `SDL_GPUTexture` for UI thumbnails.
+2.  **Processing**: When a filter parameter is adjusted in the UI, the `ImageEditor` updates the corresponding GEGL node in the graph.
+3.  **Rendering**: A background thread processes the GEGL graph and uploads the result to a GPU texture, which is then displayed by ImGui.
+4.  **Database**: SQLite is used to store and search image metadata, allowing for fast retrieval and organization of large image rolls.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -1,0 +1,64 @@
+# Workflows and Call-Stacks
+
+This document provides example call-stacks for major operations within UNFV3.
+
+## 1. Loading an Image Roll
+
+When a user selects "Load Roll" from the menu:
+
+```text
+main()
+└── render_menu_bar()
+    └── SDL_ShowOpenFolderDialog() (Async Callback)
+        └── load_roll_callback()
+            └── AppState::pending_session_paths.push_back()
+
+main() (Next Frame)
+└── process_pending_sessions()
+    └── Session::Session()
+        └── ImageManager::ImageManager()
+            └── ImageManager::load_folder()
+                └── ImageManager::load_thumbnails()
+```
+
+## 2. Applying an Image Effect (e.g., Exposure)
+
+When a user adjusts the "Exposure" slider in the UI:
+
+```text
+main()
+└── render_sessions()
+    └── Session::render_manager() [via ImageManager]
+        └── ImageEditor::render_controls()
+            └── ImGui::SliderFloat("Exposure") (User Input)
+                └── ImageEditor::get_or_create_effect(EffectType::Exposure)
+                    └── gegl_node_set(exposure_node, "exposure", value)
+                    └── ImageEditor::put_render_request()
+```
+
+## 3. Background Image Rendering
+
+Triggered after a render request is put into the queue:
+
+```text
+ImageEditor::render_thread() (Worker Loop)
+└── ImageEditor::apply_gegl_texture()
+    └── gegl_node_process(sink)
+    └── SDL_AcquireGPUCommandBuffer()
+    └── upload_texture_data_to_gpu()
+    └── SDL_SubmitGPUCommandBuffer()
+```
+
+## 4. Exporting Processed Images
+
+When the user initiates an export:
+
+```text
+Session::render_export_modal()
+└── Session::start_export()
+    └── Session::export_images() (New Thread)
+        └── Session::process_pending_image()
+            └── ImageEditor::load_path()
+            └── gegl_node_process(file_sink)
+            └── [Optional] OpenCV Watermarking
+```

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,162 @@
+project('UNFV3', 'cpp', 'c',
+  version : '0.1',
+  meson_version : '>= 1.1',
+  default_options : ['cpp_std=c++20', 'c_std=c11', 'buildtype=release', 'optimization=3', 'b_lto=true']
+)
+
+cmake = import('cmake')
+cpp = meson.get_compiler('cpp')
+
+if cpp.get_id() in ['gcc', 'clang']
+  add_project_arguments('-fomit-frame-pointer', language : ['c', 'cpp'])
+elif cpp.get_id() == 'msvc'
+  # MSVC speed optimisations (function-level linking, data-section splitting)
+  add_project_arguments('/Gy', '/Gw', language : ['c', 'cpp'])
+endif
+
+# --- Dependencies ---
+
+# GEGL (Mandatory System Dependency)
+gegl_dep = dependency('gegl-0.4', required : true)
+
+# SDL3 (Vendored)
+sdl_opts = cmake.subproject_options()
+sdl_opts.add_cmake_defines({
+  'SDL_SHARED': 'OFF',
+  'SDL_STATIC': 'ON',
+  'SDL_TEST': 'OFF',
+})
+sdl_subproj = cmake.subproject('SDL', options: sdl_opts, required: true)
+sdl_dep = sdl_subproj.dependency('SDL3-static')
+
+# OpenCV (Vendored)
+opencv_opts = cmake.subproject_options()
+opencv_opts.add_cmake_defines({
+  'BUILD_LIST': 'core,imgproc,imgcodecs,dnn,objdetect',
+  'BUILD_TESTS': 'OFF',
+  'BUILD_PERF_TESTS': 'OFF',
+  'BUILD_EXAMPLES': 'OFF',
+  'BUILD_DOCS': 'OFF',
+  'WITH_IPP': 'OFF',
+  'WITH_OPENCL': 'OFF',
+  'WITH_OPENGL': 'OFF',
+  'WITH_CUDA': 'OFF',
+  'WITH_KLEIDICV': 'OFF',
+  'BUILD_opencv_apps': 'OFF',
+})
+
+# ImGui (Static Library from source)
+imgui_inc = include_directories(
+  'vendored/imgui',
+  'vendored/imgui/backends',
+  'vendored/imgui/misc/cpp'
+)
+
+imgui_src = files(
+  'vendored/imgui/imgui.cpp',
+  'vendored/imgui/imgui_draw.cpp',
+  'vendored/imgui/imgui_tables.cpp',
+  'vendored/imgui/imgui_widgets.cpp',
+  'vendored/imgui/imgui_demo.cpp',
+  'vendored/imgui/backends/imgui_impl_sdl3.cpp',
+  'vendored/imgui/backends/imgui_impl_sdlgpu3.cpp',
+  'vendored/imgui/misc/cpp/imgui_stdlib.cpp'
+)
+
+imgui_lib = static_library('imgui',
+  imgui_src,
+  include_directories : [imgui_inc],
+  dependencies : [sdl_dep]
+)
+
+imgui_dep = declare_dependency(
+  link_with : imgui_lib,
+  include_directories : imgui_inc
+)
+
+# SQLite (Static Library from source)
+sqlite_inc = include_directories('vendored/sqlite-amalgamation-3510200')
+sqlite_lib = static_library('sqlite',
+  'vendored/sqlite-amalgamation-3510200/sqlite3.c',
+  include_directories : sqlite_inc,
+  c_args : [
+    '-DSQLITE_ENABLE_FTS5',
+    '-DSQLITE_ENABLE_JSON1',
+    '-DSQLITE_ENABLE_RTREE',
+    '-DSQLITE_THREADSAFE=2',
+    '-DSQLITE_DEFAULT_MEMSTATUS=0',
+    '-DSQLITE_LIKE_DOESNT_MATCH_BLOBS',
+    '-DSQLITE_MAX_EXPR_DEPTH=0',
+    '-DSQLITE_OMIT_DEPRECATED',
+    '-DSQLITE_USE_ALLOCA'
+  ]
+)
+sqlite_dep = declare_dependency(
+  link_with : sqlite_lib,
+  include_directories : sqlite_inc
+)
+
+# nlohmann_json
+json_dep = declare_dependency(include_directories : include_directories('vendored/json'))
+
+# Tracy (Optional)
+tracy_dep = []
+if get_option('tracy')
+  tracy_subproj = subproject('tracy')
+  tracy_dep = tracy_subproj.get_variable('tracy_dep')
+  add_project_arguments('-DTRACY_ENABLE', language : 'cpp')
+endif
+
+# --- Main Application ---
+
+src = files(
+  'src/main.cpp',
+  'src/Application/database.cpp',
+  'src/Application/session.cpp',
+  'src/Application/search_engine.cpp',
+  'src/Application/detection.cpp',
+  'src/Application/ui.cpp',
+  'src/Application/image_editor.cpp',
+  'src/Application/image.cpp',
+  'src/Application/gpu_utils.cpp',
+  'src/Application/operations/gimp_levels.cpp',
+  'src/Application/operations/my_colour_enhance.cpp'
+)
+
+app_inc = include_directories('src/Application')
+
+extra_libs = []
+if host_machine.system() == 'windows'
+  extra_libs += [
+    cpp.find_library('ws2_32'),
+    cpp.find_library('comctl32'),
+    cpp.find_library('setupapi'),
+    cpp.find_library('version')
+  ]
+endif
+
+# OpenCV as a subproject
+opencv_subproj = cmake.subproject('opencv', options: opencv_opts, required: true)
+# Map OpenCV libraries manually as they might not be cleanly exported by the cmake module in all versions
+opencv_dep = [
+  opencv_subproj.dependency('opencv_core'),
+  opencv_subproj.dependency('opencv_imgproc'),
+  opencv_subproj.dependency('opencv_imgcodecs'),
+  opencv_subproj.dependency('opencv_dnn'),
+  opencv_subproj.dependency('opencv_objdetect')
+]
+
+executable('UNFV3',
+  src,
+  include_directories : app_inc,
+  dependencies : [
+    gegl_dep,
+    sdl_dep,
+    opencv_dep,
+    imgui_dep,
+    sqlite_dep,
+    json_dep,
+    tracy_dep
+  ] + extra_libs,
+  install : true
+)

--- a/meson.options
+++ b/meson.options
@@ -1,0 +1,1 @@
+option('tracy', type: 'boolean', value: false, description: 'Enable Tracy profiler instrumentation')

--- a/subprojects/SDL
+++ b/subprojects/SDL
@@ -1,0 +1,1 @@
+../vendored/SDL

--- a/subprojects/opencv
+++ b/subprojects/opencv
@@ -1,0 +1,1 @@
+../vendored/opencv

--- a/subprojects/tracy.wrap
+++ b/subprojects/tracy.wrap
@@ -1,0 +1,7 @@
+[wrap-git]
+url = https://github.com/wolfpld/tracy.git
+revision = v0.13.1
+depth = 1
+
+[provide]
+tracy = tracy_dep


### PR DESCRIPTION
This PR migrates the UNFV3 project from CMake to a modern, highly optimized Meson build system. It also introduces a comprehensive documentation suite and a detailed build guide.

Key Changes:
1. **Meson Migration**: The build system is now based on Meson (>= 1.1). GEGL and OpenCV are mandatory dependencies. Vendored SDL3 and OpenCV are integrated as subprojects.
2. **Optimizations**: Release builds are now configured with `-O3`, LTO, and platform-specific compiler flags (`-fomit-frame-pointer` for GCC/Clang, `/Gy` and `/Gw` for MSVC).
3. **Tracy Support**: Optional Tracy profiler support is maintained via the `tracy` option and a `.wrap` file for dependency management.
4. **Documentation**: A new `docs/` directory contains `architecture.md`, `api.md`, and `workflows.md`, providing a deep dive into the software's design and operations.
5. **Build Guide**: `HOWTOBUILD.md` offers step-by-step instructions for development and distribution builds across Linux, Windows, and macOS.
6. **Subprojects**: A `subprojects/` directory is created to manage internal dependencies using symlinks to existing `vendored/` paths and a wrap file for external ones.

---
*PR created automatically by Jules for task [6218056253954062254](https://jules.google.com/task/6218056253954062254) started by @clodman84*